### PR TITLE
Several minor fixes for issues mentioned in taiga

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ run-fg:
 build:
 	@ docker-compose build --no-cache
 
-.PHONY: ssh-gen3-cli
+.PHONY: shell
 .ONESHELL:
-ssh-gen3-cli:
+shell:
 	@ docker-compose exec gen3-cli /bin/bash

--- a/gen3-cli/Makefile
+++ b/gen3-cli/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 .ONESHELL:
-test:
+tests:
 	@ pytest tests -vv -x
 
 .PHONY: coverage
@@ -13,7 +13,7 @@ coverage:
 .PHONY: lint
 .ONESHELL:
 lint:
-	@ PYTHONDONTWRITEBYTECODE=1 flake8 --exit-zero --config=.flake8 cot tests setup.py 
+	@ PYTHONDONTWRITEBYTECODE=1 flake8 --exit-zero --config=.flake8 cot tests setup.py
 
 .PHONY: install
 .ONESHELL:

--- a/gen3-cli/cot/command/create/template.py
+++ b/gen3-cli/cot/command/create/template.py
@@ -30,7 +30,8 @@ from cot import utils
             "application"
         ],
         case_sensitive=False
-    )
+    ),
+    required=True
 )
 @click.option(
     '-q',
@@ -46,7 +47,8 @@ from cot import utils
 @click.option(
     '-u',
     '--deployment-unit',
-    help='deployment unit to be included in the template'
+    help='deployment unit to be included in the template',
+    required=True
 )
 @click.option(
     '-z',

--- a/gen3-cli/cot/command/manage/deployment.py
+++ b/gen3-cli/cot/command/manage/deployment.py
@@ -5,15 +5,11 @@ from cot import utils
 
 
 @click.command(context_settings=dict(max_content_width=240))
-@click.argument(
-    'operation',
-    type=click.Choice(
-        [
-            'update',
-            'delete'
-        ],
-        case_sensitive=False
-    )
+@click.option(
+    '-d',
+    '--delete',
+    help='delete the deployment',
+    is_flag=True
 )
 @click.option(
     '-i',
@@ -88,7 +84,7 @@ from cot import utils
     help='subset of the deployment unit required'
 )
 def deployment(
-    operation,
+    delete,
     deployment_initiate,
     level,
     deployment_monitor,
@@ -106,7 +102,7 @@ def deployment(
         env.GENERATION_DIR,
         'manageDeployment.sh',
         options={
-            '-d': operation == 'delete',
+            '-d': delete,
             '-i': deployment_initiate,
             '-m': deployment_monitor,
             '-l': level,

--- a/gen3-cli/cot/command/manage/stack.py
+++ b/gen3-cli/cot/command/manage/stack.py
@@ -5,15 +5,11 @@ from cot import utils
 
 
 @click.command(context_settings=dict(max_content_width=240))
-@click.argument(
-    'operation',
-    type=click.Choice(
-        [
-            'delete',
-            'update'
-        ],
-        case_sensitive=False
-    )
+@click.option(
+    '-d',
+    '--delete',
+    help='delete the stack',
+    is_flag=True
 )
 @click.option(
     '-i',
@@ -81,7 +77,7 @@ from cot import utils
     help='show what will happen without actually updating the stack'
 )
 def stack(
-    operation,
+    delete,
     stack_initiate,
     stack_monitor,
     stack_wait,
@@ -110,7 +106,7 @@ def stack(
         env.GENERATION_DIR,
         'manageStack.sh',
         options={
-            '-d': operation == 'delete',
+            '-d': delete,
             '-i': stack_initiate,
             '-m': stack_monitor,
             '-w': stack_wait,


### PR DESCRIPTION
1. Changed ```deployment-unit``` and ```level``` options to mandatory in ```create template command```.
1. Restored original ```manage stack|deployment``` syntax. 
1. Renamed ```make ssh-gen3-client``` to ```make shell```

I'll move issues in taiga when this PR will be merged. 