### PR TITLE
Updates:

### DIFF
--- a/gen3-cli/Dockerfile
+++ b/gen3-cli/Dockerfile
@@ -1,5 +1,5 @@
 # BASE IMAGE
-FROM codeontap/gen3 AS base
+FROM codeontap/gen3:latest-builder AS base
 
 COPY . /gen3-cli
 WORKDIR /gen3-cli

--- a/gen3-cli/MANIFEST.in
+++ b/gen3-cli/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.md
+include *.sh

--- a/gen3-cli/Makefile
+++ b/gen3-cli/Makefile
@@ -19,7 +19,7 @@ lint:
 .ONESHELL:
 install:
 	pip uninstall codeontap-cli -y
-	python setup.py bdist_wheel clean --all
+	python setup.py sdist clean --all
 	rm -rf codeontap_cli.egg-info
 	pip install --no-index --find-links=dist codeontap-cli
 

--- a/gen3-cli/cot/__init__.py
+++ b/gen3-cli/cot/__init__.py
@@ -1,7 +1,7 @@
 # Here we controll modules loading order
 # We can do it in command.__init__ but I guess this is a little bit more explicit
 import cot.command  # noqa
-import cot.command.generate
+import cot.command.generate  # noqa
 import cot.command.create  # noqa
 # import cot.command.add  # noqa
 import cot.command.manage  # noqa

--- a/gen3-cli/cot/__init__.py
+++ b/gen3-cli/cot/__init__.py
@@ -1,6 +1,7 @@
 # Here we controll modules loading order
 # We can do it in command.__init__ but I guess this is a little bit more explicit
 import cot.command  # noqa
+import cot.command.generate
 import cot.command.create  # noqa
 # import cot.command.add  # noqa
 import cot.command.manage  # noqa

--- a/gen3-cli/cot/command/generate/__init__.py
+++ b/gen3-cli/cot/command/generate/__init__.py
@@ -1,0 +1,15 @@
+from cot.command import root as cli
+from .cmdb import group as cmdb_generation_group
+from .product import group as product_generation_group
+
+
+@cli.group('generate')
+def group():
+    """
+    Generate various cmdb components
+    """
+    pass
+
+
+group.add_command(cmdb_generation_group)
+group.add_command(product_generation_group)

--- a/gen3-cli/cot/command/generate/cmdb.py
+++ b/gen3-cli/cot/command/generate/cmdb.py
@@ -1,0 +1,34 @@
+import os
+from cookiecutter.main import cookiecutter
+import click
+from cot import conf
+
+
+TEMPLATES_DIR = os.path.join(conf.COOKIECUTTER_TEMPLATES_BASE_DIR, 'cmdb')
+
+
+@click.group('cmdb')
+def group():
+    pass
+
+
+@group.command('account')
+def generate_account():
+    """
+    This template is for the creation of a codeontap account.
+    The account template can be reused to create multiple accounts within a Tenant.
+
+    This template should be run from a tenant directory
+    """
+    template_path = os.path.join(TEMPLATES_DIR, 'account')
+    cookiecutter(template_path)
+
+
+@group.command('tenant')
+def generate_tenant():
+    """
+    This template is for the creation of a codeontap tenant.
+    This should be run from the root of an accounts repository.
+    """
+    template_path = os.path.join(TEMPLATES_DIR, 'tenant')
+    cookiecutter(template_path)

--- a/gen3-cli/cot/command/generate/product.py
+++ b/gen3-cli/cot/command/generate/product.py
@@ -1,0 +1,54 @@
+import os
+from cookiecutter.main import cookiecutter
+import click
+from cot import conf
+
+
+TEMPLATES_DIR = os.path.join(conf.COOKIECUTTER_TEMPLATES_BASE_DIR, 'products')
+
+
+@click.group('product')
+def group():
+    pass
+
+
+@group.command('base')
+def generate_base():
+    """
+    This template is for the creation of a codeontap product.
+    This creates a base product with no deployed components.
+    This template should be run from the root of an empty product directory.
+    """
+    template_path = os.path.join(TEMPLATES_DIR, 'base')
+    cookiecutter(template_path)
+
+
+@group.command('app-lifecycle-mgmt')
+def generate_app_lifecycle_mgmt():
+    """
+    This template is for the creation of a codeontap product.
+    This product provisions a container based application lifecycle management service used
+    to build and deploy codeontap managed applications.
+    """
+    template_path = os.path.join(TEMPLATES_DIR, 'app-lifecycle-mgmt')
+    cookiecutter(template_path)
+
+
+@group.command('django')
+def generate_django():
+    """
+    This template is for the creation of an AWS based Django deployment. It includes all of the components
+    required for a produciton level deployment of Django:
+
+    - Web ECS Service for front end
+    - Worker ECS Service for celery processing
+    - Task ECS Task Definition for Django management
+    - Postgres based RDS instance
+    - Cloudfront S3 distribution for static content
+    - Redis for queue management between web and worker
+    - HTTPS offloading load balancer for web
+
+    The template will create a single environment. If you want more you will need too add them manually.
+    """
+    template_path = os.path.join(TEMPLATES_DIR, 'django-cookiecutter')
+    cookiecutter(template_path)

--- a/gen3-cli/cot/conf.py
+++ b/gen3-cli/cot/conf.py
@@ -1,0 +1,1 @@
+COOKIECUTTER_TEMPLATES_BASE_DIR = '/opt/codeontap/patterns'

--- a/gen3-cli/requirements/dev.txt
+++ b/gen3-cli/requirements/dev.txt
@@ -3,3 +3,4 @@ pytest
 freezegun
 setuptools
 flake8
+wheel

--- a/gen3-cli/requirements/prod.txt
+++ b/gen3-cli/requirements/prod.txt
@@ -1,1 +1,2 @@
 Click
+cookiecutter

--- a/gen3-cli/requirements/prod.txt
+++ b/gen3-cli/requirements/prod.txt
@@ -1,2 +1,2 @@
-Click
-cookiecutter
+Click==7.0
+cookiecutter==1.6.0

--- a/gen3-cli/setup-autocomplete.sh
+++ b/gen3-cli/setup-autocomplete.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+if [[ $(basename $SHELL) = 'bash' ]];
+then
+    if [ -f ~/.bashrc ];
+    then
+        echo "Installing bash autocompletion..."
+        grep -q 'cot-autocompletion' ~/.bashrc
+        if [[ $? -ne 0 ]]; then
+            echo "" >> ~/.bashrc
+            echo 'eval "$(_COT_COMPLETE=source cot)"' >> ~/.cot-autocompletion.sh
+            echo "source ~/.cot-autocompletion.sh" >> ~/.bashrc
+        fi
+    fi
+elif [[ $(basename $SHELL) = 'zsh' ]];
+then
+    if [ -f ~/.zshrc ];
+    then
+        echo "Installing zsh autocompletion..."
+        grep -q 'cot-autocompletion' ~/.zshrc
+        if [[ $? -ne 0 ]]; then
+            echo "" >> ~/.zshrc
+            echo "autoload bashcompinit" >> ~/.zshrc
+            echo "bashcompinit" >> ~/.zshrc
+            echo 'eval "$(_COT_COMPLETE=source cot)"' >> ~/.cot-autocompletion.sh
+            echo "source ~/.cot-autocompletion.sh" >> ~/.zshrc
+        fi
+    fi
+fi

--- a/gen3-cli/setup.cfg
+++ b/gen3-cli/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/gen3-cli/setup.py
+++ b/gen3-cli/setup.py
@@ -1,6 +1,24 @@
+import subprocess
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+
 
 packages = find_packages(exclude=["tests.*", "tests"])
+
+
+class InstallCommand(install):
+
+    def __post_install(self, dir):
+        subprocess.call(['./setup-autocomplete.sh'])
+
+    def run(self):
+        install.run(self)
+        self.execute(
+            self.__post_install,
+            (self.install_lib,),
+            msg='Setting up autocomplete...'
+        )
+
 
 print(packages)
 
@@ -11,9 +29,13 @@ setup(
     install_requires=[
         'Click',
     ],
+    include_package_data=True,
     entry_points={
         'console_scripts': [
             'cot=cot:command.root'
         ]
+    },
+    cmdclass={
+        'install': InstallCommand
     }
 )


### PR DESCRIPTION
1. Autocomplete
2. Changed distribution format to source dist
3. Wrapped cookiecutter into cli
4. Updated base image to latest

To enable autocomplete you need to:
1. ```make ssh```
2. ```make install```
3. ```exit```
4. ```make shell```
5. ```cot gen[tab]``` 