### PR TITLE
Added source ~/.bashrc to test run command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,4 +12,4 @@ jobs:
     - name: Run the compose network
       run: make run
     - name: Run the tests
-      run: docker-compose exec gen3-cli /bin/bash -c -i 'make tests'
+      run: docker-compose exec gen3-cli /bin/bash -c 'source ~/.bashrc && make tests'


### PR DESCRIPTION
This should fix the problem of our PR testing. The interactive shell is not working, therefore, the only option that is left is direct ```source ~/.bashrc```. 