### PR TITLE
<fix> Include templates in setup

### DIFF
--- a/gen3-cli/MANIFEST.in
+++ b/gen3-cli/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.md
 include setup-autocomplete.sh
+include cot/backend/test/templates/*.tmpl

--- a/gen3-cli/setup.py
+++ b/gen3-cli/setup.py
@@ -24,10 +24,16 @@ print(packages)
 
 setup(
     name='codeontap-cli',
-    version='0.1',
+    version='0.1.0',
     packages=packages,
     install_requires=[
-        'Click',
+        'click>=7.0.0,<8.0.0',
+        'pytest>=5.0.0,<6.0.0',
+        'cookiecutter>=1.7.0,<2.0.0',
+        'tabulate>=0.8.0,<1.0.0',
+        'Jinja2>=2.10.0,<3.0.0',
+        'cfn-lint>=0.26.0,<1.0.0',
+        'cfn-flip>=1.2.0,<2.0.0',
     ],
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
A couple of minor fixes from testing and installation into the codeontap/gen3 image 

- Template files not included in installed package for generating tests
- Add basic package requirements for setup