### PR TITLE
removed deployment-name and replaced with resource-group option.

### DIFF
--- a/gen3-cli/cot/backend/manage/deployment/__init__.py
+++ b/gen3-cli/cot/backend/manage/deployment/__init__.py
@@ -3,10 +3,10 @@ from cot.backend.common import runner
 
 def run(
     delete=None,
+    resource_group=None,
     deployment_initiate=None,
     level=None,
     deployment_monitor=None,
-    deployment_name=None,
     region=None,
     deployment_scope=None,
     deployment_unit=None,
@@ -16,10 +16,10 @@ def run(
 ):
     options = {
         '-d': delete,
+        '-g': resource_group,
         '-i': deployment_initiate,
         '-m': deployment_monitor,
         '-l': level,
-        '-n': deployment_name,
         '-r': region,
         '-s': deployment_scope,
         '-u': deployment_unit,

--- a/gen3-cli/cot/command/manage/deployment.py
+++ b/gen3-cli/cot/command/manage/deployment.py
@@ -16,6 +16,11 @@ from cot.backend.manage import deployment as manage_deployment_backend
     is_flag=True
 )
 @click.option(
+    '-g',
+    '--resource-group',
+    help='target resource group for the deployment.',
+)
+@click.option(
     '-i',
     '--deployment-initiate',
     help='initiate but do not monitor the deployment operation(disable monitoring)',
@@ -43,11 +48,6 @@ from cot.backend.manage import deployment as manage_deployment_backend
     '--deployment-monitor',
     help='monitor but do not initiate the deployment operation(disable initiation)',
     is_flag=True
-)
-@click.option(
-    '-n',
-    '--deployment-name',
-    help='override the standard deployment naming'
 )
 @click.option(
     '-r',

--- a/gen3-cli/tests/unit/command/manage/test_deployment.py
+++ b/gen3-cli/tests/unit/command/manage/test_deployment.py
@@ -15,9 +15,9 @@ ALL_VALID_OPTIONS['!-l,--level'] = [
     'multiple'
 ]
 ALL_VALID_OPTIONS['-d,--delete'] = [True, False]
+ALL_VALID_OPTIONS['-g,--resource-group'] = 'group'
 ALL_VALID_OPTIONS['-i,--deployment-initiate'] = [True, False]
 ALL_VALID_OPTIONS['-m,--deployment-monitor'] = [True, False]
-ALL_VALID_OPTIONS['-n,--deployment-name'] = 'name'
 ALL_VALID_OPTIONS['-r,--region'] = 'region'
 ALL_VALID_OPTIONS['-s,--deployment-scope'] = [
     'subscription',


### PR DESCRIPTION
Updating the options on ```cot manage deployment``` to reflect the changes made to the manageDeployment.sh script in codeontap/gen3#1090

- removed --deployment-name as its now being defined within the script and used to name the deployment but not the resultant resource group.
- added --resource-group -g to replace it.