### PR TITLE
incorporated output option which is required for mocking.

### DIFF
--- a/gen3-cli/cot/backend/create/template/__init__.py
+++ b/gen3-cli/cot/backend/create/template/__init__.py
@@ -15,6 +15,7 @@ def run(
     generation_testcase=None,
     generation_scenarios=None,
     generation_input_source=None,
+    output_dir=None,
     _is_cli=False
 ):
     options = {
@@ -30,6 +31,7 @@ def run(
         '-f': generation_framework,
         '-t': generation_testcase,
         '-s': generation_scenarios,
-        '-i': generation_input_source
+        '-i': generation_input_source,
+        '-o': output_dir
     }
     runner.run('createTemplate.sh', [], options, _is_cli)

--- a/gen3-cli/cot/command/create/template.py
+++ b/gen3-cli/cot/command/create/template.py
@@ -94,6 +94,11 @@ from cot.backend.create import template as create_template_backend
     '--generation-input-source',
     help='source of input data to use when generating the template'
 )
+@click.option(
+    '-o',
+    '--output-dir',
+    help='the directory where the outputs will be saved. Mandatory when Input Source set to Mock.'
+)
 def template(**kwargs):
     """
     Create a CloudFormation (CF) template

--- a/gen3-cli/tests/unit/command/create/test_template.py
+++ b/gen3-cli/tests/unit/command/create/test_template.py
@@ -25,6 +25,7 @@ ALL_VALID_OPTIONS['-f,--generation-framework'] = 'generation_framework'
 ALL_VALID_OPTIONS['-t,--generation-testcase'] = 'generation_testcase'
 ALL_VALID_OPTIONS['-s,--generation-scenarios'] = 'generation_scenarios'
 ALL_VALID_OPTIONS['-i,--generation-input-source'] = 'generation_input_source'
+ALL_VALID_OPTIONS['-o,--output-dir'] = 'output_dir'
 
 
 @mock.patch('cot.command.create.template.create_template_backend')


### PR DESCRIPTION
When the Input Sources on create template is set to "Mock", the output sources is a mandatory option.

 ```cot create template -i mock -o /opt/tempdir ...```

This PR implements the OUTPUT_DIR option so that it is available, however it does not enforce the mandatory nature of this argument as it is only mandatory under certain circumstances.