### PR TITLE
<fix> Unlock cfn-lint version

### DIFF
--- a/gen3-cli/requirements/dev.txt
+++ b/gen3-cli/requirements/dev.txt
@@ -1,8 +1,5 @@
 coverage
-pytest
 freezegun
 setuptools
 flake8
 wheel
-cfn-lint==0.25.7
-cfn-flip==1.2.2

--- a/gen3-cli/requirements/prod.txt
+++ b/gen3-cli/requirements/prod.txt
@@ -4,3 +4,8 @@ tabulate==0.8.6
 Jinja2==2.10.3
 marshmallow==3.3.0
 jmespath==0.9.4
+pytest
+
+# AWS specifc tools
+cfn-flip==1.2.2
+cfn-lint>=0.25.0,<1.0.0 # need version to keep up with AWS CloudFormation Schema


### PR DESCRIPTION
minor change to requirements 

- pytest would be a production dependency now that its used as part of an actual command
- unlock cfn-lint as its releases include updates to the CloudFormation Specification that needs to keep up with what AWS has released